### PR TITLE
FIX: typography of render-and-commit article

### DIFF
--- a/src/content/learn/render-and-commit.md
+++ b/src/content/learn/render-and-commit.md
@@ -67,7 +67,7 @@ export default function Image() {
 
 ### Ре-рендер, когда состояние обновляется {/*re-renders-when-state-updates*/}
 
-После того как компонент был первоначально отрендерен, вы можете инициировать последующие рендеры, обновляя его состояние с помощью функции [`set`](/reference/react/useState#setstate) Обновление состояние компонента автоматически ставит его в очередь на рендер. (Вы можете представить это как посетитель ресторана, который после первого заказа заказывает чай, десерт и всевозможные вещи, в зависимости от состояния жажды или голода).
+После того как компонент был первоначально отрендерен, вы можете инициировать последующие рендеры, обновляя его состояние с помощью функции [`set`](/reference/react/useState#setstate). Обновление состояние компонента автоматически ставит его в очередь на рендер. (Вы можете представить это как посетитель ресторана, который после первого заказа заказывает чай, десерт и всевозможные вещи, в зависимости от состояния жажды или голода).
 
 <IllustrationBlock sequential>
   <Illustration caption="State update..." alt="React as a server in a restaurant, serving a Card UI to the user, represented as a patron with a cursor for their head. They patron expresses they want a pink card, not a black one!" src="/images/docs/illustrations/i_rerender1.png" />
@@ -124,7 +124,7 @@ img { margin: 0 10px 10px 0; }
 
 </Sandpack>
 
-* **На начальном рендере,** React [создаст DOM ноды](https://developer.mozilla.org/docs/Web/API/Document/createElement) для `<section>`, `<h1>`, и трёзх `<img>` тегов. 
+* **На начальном рендере,** React [создаст DOM ноды](https://developer.mozilla.org/docs/Web/API/Document/createElement) для `<section>`, `<h1>`, и трёх `<img>` тегов. 
 * **Во время повторного ре-рендеринга,** React вычислит, какие из их свойств, если таковые имеются, изменились с момента предыдущего рендеринга. Он ничего не будет делать с этой информацией до следующего шага, фазы фиксации.
 
 <Pitfall>


### PR DESCRIPTION
Привееет 👋
Нашёл в тексте одну опечатку, и возможно, ещё одну пунктуационную ошибку, закинул PR :)

#

**Если ваш пулреквест является исправлением бага, а не переводом, то сперва убедитесь, что проблема относится ТОЛЬКО к https://ru.reactjs.org, а не к https://reactjs.org.** Если это не так, то пулреквест следует открыть в родительском репозитории.

<!--
Прежде чем создавать пулреквест, пожалуйста, прочтите полностью правила перевода по ссылке ниже и поправьте свой перевод:

https://github.com/reactjs/ru.reactjs.org/blob/master/TRANSLATION.md

ВНИМАНИЕ: 90% переводов страдают от одной и той же проблемы: нагромождения существительных.
Пройдитесь по переводу и поправьте его *сейчас*, чтобы не тратить время на ревью.

Пример «до»: «Объявление переменной и использование её в `if`-выражении это вполне рабочий вариант условного рендеринга.»
Пример «после»: «Нет ничего плохого в том, чтобы объявить переменную и условно рендерить компонент `if`-выражением.»

Берегите глаголы!
-->
